### PR TITLE
fix(canvas): prevent stylus hover assertions

### DIFF
--- a/lib/design_system/components/atoms/app_icon_button.dart
+++ b/lib/design_system/components/atoms/app_icon_button.dart
@@ -14,6 +14,8 @@ class AppIconButton extends StatelessWidget {
     this.semanticLabel,
     this.shape = const CircleBorder(), // 필요하면 RoundedRectangleBorder로
     this.color,
+    this.enabledMouseCursor = MouseCursor.defer,
+    this.disabledMouseCursor = MouseCursor.defer,
   });
 
   final String svgPath;
@@ -23,6 +25,8 @@ class AppIconButton extends StatelessWidget {
   final String? semanticLabel;
   final OutlinedBorder shape;
   final Color? color;
+  final MouseCursor enabledMouseCursor;
+  final MouseCursor disabledMouseCursor;
 
   @override
   Widget build(BuildContext context) {
@@ -45,6 +49,8 @@ class AppIconButton extends StatelessWidget {
         minimumSize: Size(side, side),
         padding: EdgeInsets.zero,
         shape: shape, // 기본 원형
+        enabledMouseCursor: enabledMouseCursor,
+        disabledMouseCursor: disabledMouseCursor,
         // 배경/테두리/foreground 색 계산 없음
       ),
       icon: SvgPicture.asset(

--- a/lib/features/vaults/pages/vault_graph_screen.dart
+++ b/lib/features/vaults/pages/vault_graph_screen.dart
@@ -95,6 +95,9 @@ class _VaultGraphScreenState extends ConsumerState<VaultGraphScreen> {
           final options = Options();
           options.enableHit = true;
           options.panelDelay = const Duration(milliseconds: 200);
+          // edgePanelBuilder가 null이면 패키지가 오버레이를 등록하지 않아 assertion이 발생하므로
+          // 빈 빌더를 명시해 오버레이 등록만 수행하고 아무것도 그리지 않도록 한다.
+          options.edgePanelBuilder = (_, __) => const SizedBox.shrink();
           options.textGetter = (vertex) {
             final t = vertex.tag;
             return t.isEmpty ? '${vertex.id}' : t;


### PR DESCRIPTION
  - default AppIconButton mouse cursors to defer so tooltip hover no longer flips stylus pointers into mouse mode and triggers MouseTracker asserts
  - register a no-op edgePanelBuilder for the vault graph so flutter_graph_view always has an overlay entry before edge hover adds it